### PR TITLE
Add Makefile, edit dockerfile and config.yml for CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
             sudo rm -rf /usr/local/go
             sudo tar -C /usr/local -xzf go1.12.6.linux-amd64.tar.gz
       - checkout
+      - run: make test
       - run: make test-coverage
   create-push-docker-image:
     executor: my-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,6 @@ executors:
       IMAGE_NAME: vladwoode/social-tournament-service
     docker:
       - image: circleci/golang:1.12
-        environment:
-          - GO111MODULE=on
     working_directory: /go/src/github.com/HarlamovBuldog/social-tournament-service
 
 jobs:
@@ -15,7 +13,7 @@ jobs:
     executor: my-executor
     steps:
       - checkout
-      - run: go build -mod=vendor ./...
+      - run: make build
   test:
     machine:
       image: ubuntu-1604:201903-01
@@ -29,7 +27,7 @@ jobs:
             sudo rm -rf /usr/local/go
             sudo tar -C /usr/local -xzf go1.12.6.linux-amd64.tar.gz
       - checkout
-      - run: env GO111MODULE=on go test -mod=vendor -v -cover ./...
+      - run: make test-coverage
   create-push-docker-image:
     executor: my-executor
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Goland config files
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 
 # Build the Go app.
 # Rusulting files will be inside /go/bin/social-tournament-service
-RUN env GO111MODULE=on CGO_ENABLED=0 GOOS=linux go install -mod=vendor -a ./...
+RUN make build
 
 # Start a new build stage
 FROM scratch
@@ -20,7 +20,7 @@ FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 # Copy the Pre-built binary file from the previous stage
-COPY --from=builder /go/bin/social-tournament-service main
+COPY --from=builder /go/bin/social-tournament-service sts
 
 # Starting bash  
-ENTRYPOINT ["./main"]
+ENTRYPOINT ["./sts"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+BINARY_NAME = "sts"
+
+build:
+	env GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -mod=vendor -o $(BINARY_NAME)
+
+run:
+	env GO111MODULE=on go build -mod=vendor -o $(BINARY_NAME)
+	./$(BINARY_NAME)
+
+test:
+	env GO111MODULE=on go test -mod=vendor -v ./...
+
+test-coverage:
+	go get github.com/mattn/goveralls && \
+	env GO111MODULE=on go test -mod=vendor -v -cover -coverprofile ~/coverage.out.tmp ./... && \
+	cat ~/coverage.out.tmp | grep -v "_mock.go" > ~/coverage.out && \
+	~/go/bin/goveralls -coverprofile ~/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
+
+clean:
+	rm -f $(BINARY_NAME)
+	env GO111MODULE=on go clean -mod=vendor

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,12 @@ run:
 	./$(BINARY_NAME)
 
 test:
-	env GO111MODULE=on go test -mod=vendor -v ./...
-
-test-coverage:
-	go get github.com/mattn/goveralls && \
+	env GO111MODULE=off go get golang.org/x/tools/cmd/cover
 	env GO111MODULE=on go test -mod=vendor -v -cover -coverprofile ~/coverage.out.tmp ./... && \
-	cat ~/coverage.out.tmp | grep -v "_mock.go" > ~/coverage.out && \
-	/usr/local/go/bin/goveralls -coverprofile ~/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
+    cat ~/coverage.out.tmp | grep -v "_mock.go" > ~/coverage.out
+test-coverage:
+	env GO111MODULE=off go get github.com/mattn/goveralls && \
+	$HOME/gopath/bin/goveralls -coverprofile ~/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
 
 clean:
 	rm -f $(BINARY_NAME)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test:
     cat ~/coverage.out.tmp | grep -v "_mock.go" > ~/coverage.out
 test-coverage:
 	env GO111MODULE=off go get github.com/mattn/goveralls && \
-	$HOME/gopath/bin/goveralls -coverprofile ~/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
+	$(HOME)/$(GOPATH)/bin/goveralls -coverprofile ~/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
 
 clean:
 	rm -f $(BINARY_NAME)

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ test:
 
 test-coverage:
 	go get github.com/mattn/goveralls && \
-	env GO111MODULE=on go test -mod=vendor -v -cover -coverprofile /usr/local/coverage.out.tmp ./... && \
-	cat /usr/local/coverage.out.tmp | grep -v "_mock.go" > /usr/local/coverage.out && \
-	/usr/local/go/bin/goveralls -coverprofile /usr/local/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
+	env GO111MODULE=on go test -mod=vendor -v -cover -coverprofile ~/coverage.out.tmp ./... && \
+	cat ~/coverage.out.tmp | grep -v "_mock.go" > ~/coverage.out && \
+	/usr/local/go/bin/goveralls -coverprofile ~/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
 
 clean:
 	rm -f $(BINARY_NAME)

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ test:
 
 test-coverage:
 	go get github.com/mattn/goveralls && \
-	env GO111MODULE=on go test -mod=vendor -v -cover -coverprofile ~/coverage.out.tmp ./... && \
-	cat ~/coverage.out.tmp | grep -v "_mock.go" > ~/coverage.out && \
-	~/go/bin/goveralls -coverprofile ~/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
+	env GO111MODULE=on go test -mod=vendor -v -cover -coverprofile /usr/local/coverage.out.tmp ./... && \
+	cat /usr/local/coverage.out.tmp | grep -v "_mock.go" > /usr/local/coverage.out && \
+	/usr/local/go/bin/goveralls -coverprofile /usr/local/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
 
 clean:
 	rm -f $(BINARY_NAME)

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,12 @@ run:
 	./$(BINARY_NAME)
 
 test:
-	env GO111MODULE=off go get golang.org/x/tools/cmd/cover
+	env GO111MODULE=off go get golang.org/x/tools/cmd/cover && \
 	env GO111MODULE=on go test -mod=vendor -v -cover -coverprofile ~/coverage.out.tmp ./... && \
     cat ~/coverage.out.tmp | grep -v "_mock.go" > ~/coverage.out
 test-coverage:
 	env GO111MODULE=off go get github.com/mattn/goveralls && \
-	goveralls -coverprofile ~/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
+	goveralls -coverprofile ~/coverage.out -service=circle-ci -repotoken=$(COVERALLS_TOKEN)
 
 clean:
 	rm -f $(BINARY_NAME)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test:
     cat ~/coverage.out.tmp | grep -v "_mock.go" > ~/coverage.out
 test-coverage:
 	env GO111MODULE=off go get github.com/mattn/goveralls && \
-	$(HOME)/$(GOPATH)/bin/goveralls -coverprofile ~/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
+	goveralls -coverprofile ~/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
 
 clean:
 	rm -f $(BINARY_NAME)


### PR DESCRIPTION
It contains commands for building, running, testing and cleaning project.
It has default test run and test run with triggering build on coveralls.io to check test coverage.
Last mentioned test run is used in circleci tests.
Change Dockerfile and config for CIrcleCI in order to use makefile commands.
Closes #15